### PR TITLE
Release v0.4.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,14 @@
 History
 =======
 
+0.4.0 (2022-09-21)
+------------------
+
+**Features and Improvements**
+
+* Add helper function :func:`set_default_for_missing_keys <dotwiz.set_default_for_missing_keys>`,
+  which can be used to set a *default* value to return when an attribute (key) is missing.
+
 0.3.1 (2022-06-17)
 ------------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -4,13 +4,43 @@ Usage
 
 To use ``dotwiz`` in a project::
 
-    import dotwiz
+    from dotwiz import *
 
+Default for Missing Keys
+------------------------
+
+The default behavior for :class:`DotWiz` or :class:`DotWizPlus` is
+to |raise an AttributeError|_ if an attribute (key) doesn't exist::
+
+    >>> from dotwiz import DotWiz
+    >>> DotWiz(key='test').other_key
+    Traceback (most recent call last):
+      AttributeError: 'DotWiz' object has no attribute 'other_key'
+
+The helper function :func:`set_default_for_missing_keys <dotwiz.set_default_for_missing_keys>` can be used
+to return a *default* value for any missing attributes, as shown (or ``None`` if the argument is omitted).
+This essentially implements a custom :meth:`__getattr__` on the public, exported classes.
+
+.. code:: python3
+
+    from dotwiz import DotWiz, DotWizPlus, set_default_for_missing_keys
+
+    # if omitted, the default value is `None`
+    set_default_for_missing_keys('test')
+
+    dw = DotWiz(hello='world!')
+    assert dw.hello == 'world!'
+    assert dw.world == 'test'
+
+    assert DotWizPlus().missing_key == 'test'
+
+.. |raise an AttributeError| replace:: raise an :exc:`AttributeError`
+.. _raise an AttributeError: https://github.com/rnag/dotwiz/issues/14
 
 :class:`DotWizPlus`
 -------------------
 
-Simple usage with :class:`DotWizPlus` to illustrate how keys with invalid characters
+Simple usage with :class:`DotWizPlus <dotwiz.DotWizPlus>` to illustrate how keys with invalid characters
 are made safe for attribute access:
 
 .. code:: python3
@@ -51,7 +81,7 @@ are made safe for attribute access:
 Complete Example
 ~~~~~~~~~~~~~~~~
 
-Example with :func:`make_dot_wiz_plus` to illustrate how :class:`DotWizPlus`
+Example with :func:`make_dot_wiz_plus <dotwiz.make_dot_wiz_plus>` to illustrate how :class:`DotWizPlus`
 mutates keys with invalid characters to a safe, *snake-cased* format:
 
 .. code:: python3

--- a/dotwiz/__init__.py
+++ b/dotwiz/__init__.py
@@ -28,8 +28,50 @@ __all__ = [
     'DotWiz',
     'DotWizPlus',
     'make_dot_wiz',
-    'make_dot_wiz_plus'
+    'make_dot_wiz_plus',
+    'set_default_for_missing_keys',
 ]
 
 from .main import DotWiz, make_dot_wiz
 from .plus import DotWizPlus, make_dot_wiz_plus
+
+
+def set_default_for_missing_keys(default=None, overwrite=False):
+    """
+    Modifies :class:`DotWiz` and :class:`DotWizPlus` to add a custom
+    :meth:`__getattr__`, so that accessing missing or non-existing attributes
+    (keys) returns ``default`` instead of raising an :exc:`AttributeError`.
+
+    This provides a handy alternative to the builtin :func:`hasattr`.
+
+    For more details, see https://github.com/rnag/dotwiz/issues/14.
+
+    Example::
+
+        >>> from dotwiz import DotWiz, set_default_for_missing_keys
+        >>> set_default_for_missing_keys('test')
+        >>> dw = DotWiz(hello='world!')
+        >>> assert dw.hello == 'world!'
+        >>> assert dw.world == 'test'
+
+    :param default: The default value to return for missing or non-existing
+      attributes (keys).
+    :param overwrite: True to overwrite a class's `__getattr__()` method,
+      if one already exists; defaults to False.
+
+    """
+    for cls in DotWiz, DotWizPlus:
+        cls_dict = cls.__dict__
+
+        if not overwrite and '__getattr__' in cls_dict:
+            msg = f'{cls.__qualname__} already defines a __getattr__() - ' \
+                  f'pass `overwrite=True` to continue anyway.'
+            raise ValueError(msg)
+
+        def __getattr__(self: cls, item: str,
+                        __default=default,
+                        __get=cls_dict.get):
+
+            return __get(item, __default)
+
+        setattr(cls, '__getattr__', __getattr__)

--- a/dotwiz/__version__.py
+++ b/dotwiz/__version__.py
@@ -6,7 +6,7 @@ __title__ = 'dotwiz'
 __description__ = 'DotWiz is a blazing fast dict subclass that enables ' \
                   'accessing (nested) keys in dot notation.'
 __url__ = 'https://github.com/rnag/dotwiz'
-__version__ = '0.3.1'
+__version__ = '0.4.0'
 __author__ = 'Ritvik Nag'
 __author_email__ = 'rv.kvetch@gmail.com'
 __license__ = 'MIT'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.1
+current_version = 0.4.0
 commit = True
 tag = True
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,19 @@
+"""Reusable test utilities and fixtures."""
+import pytest
+
+from dotwiz import DotWiz, DotWizPlus
+
+
+class CleanupGetAttr:
+
+    def teardown_method(self):
+        """Runs at the end of each test method in the class.
+
+        Remove :meth:`__getattr__` from all publicly exposed classes.
+
+        For more info, see:
+            * https://docs.pytest.org/en/latest/how-to/fixtures.html#teardown-cleanup-aka-fixture-finalization
+
+        """
+        del DotWiz.__getattr__
+        del DotWizPlus.__getattr__

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -13,6 +13,7 @@ class CleanupGetAttr:
 
         For more info, see:
             * https://docs.pytest.org/en/latest/how-to/fixtures.html#teardown-cleanup-aka-fixture-finalization
+            * https://docs.pytest.org/en/latest/how-to/xunit_setup.html#method-and-function-level-setup-teardown
 
         """
         del DotWiz.__getattr__

--- a/tests/unit/test_dotwiz.py
+++ b/tests/unit/test_dotwiz.py
@@ -18,6 +18,22 @@ def test_dot_wiz_with_basic_usage():
     assert dw['key-3'] == 3.21
 
 
+def test_make_dot_wiz():
+    """Confirm intended functionality of `make_dot_wiz`"""
+    dd = make_dot_wiz([(1, 'test'), ('two', [{'hello': 'world'}])],
+                      a=1, b='two', c={'d': [123]})
+
+    assert repr(dd) == "✫(a=1, b='two', c=✫(d=[123]), 1='test', two=[✫(hello='world')])"
+    assert dd.a == 1
+    assert dd.b == 'two'
+    assert dd[1] == 'test'
+    assert dd.two == [DotWiz(hello='world')]
+    assert dd.c.d[0] == 123
+
+    dd.b = [1, 2, 3]
+    assert dd.b == [1, 2, 3]
+
+
 class TestDefaultForMissingKeys(CleanupGetAttr):
 
     def test_usage(self):
@@ -47,22 +63,6 @@ class TestDefaultForMissingKeys(CleanupGetAttr):
 
         # confirm that error message correctly indicates the fix/resolution
         assert 'pass `overwrite=True`' in str(e.value)
-
-
-def test_make_dot_wiz():
-    """Confirm intended functionality of `make_dot_wiz`"""
-    dd = make_dot_wiz([(1, 'test'), ('two', [{'hello': 'world'}])],
-                      a=1, b='two', c={'d': [123]})
-
-    assert repr(dd) == "✫(a=1, b='two', c=✫(d=[123]), 1='test', two=[✫(hello='world')])"
-    assert dd.a == 1
-    assert dd.b == 'two'
-    assert dd[1] == 'test'
-    assert dd.two == [DotWiz(hello='world')]
-    assert dd.c.d[0] == 123
-
-    dd.b = [1, 2, 3]
-    assert dd.b == [1, 2, 3]
 
 
 def test_dotwiz_init():

--- a/tests/unit/test_dotwiz.py
+++ b/tests/unit/test_dotwiz.py
@@ -2,7 +2,9 @@
 
 import pytest
 
-from dotwiz import DotWiz, make_dot_wiz
+from dotwiz import *
+
+from .conftest import CleanupGetAttr
 
 
 def test_dot_wiz_with_basic_usage():
@@ -14,6 +16,37 @@ def test_dot_wiz_with_basic_usage():
     assert dw.key_1[0].k == 'v'
     assert dw.keyTwo == '5'
     assert dw['key-3'] == 3.21
+
+
+class TestDefaultForMissingKeys(CleanupGetAttr):
+
+    def test_usage(self):
+        """Basic usage of :func:`set_default_for_missing_keys`."""
+        set_default_for_missing_keys()
+
+        dw = DotWiz(HelloWorld=True)
+        assert dw.HelloWorld
+        assert dw.world is None
+
+    def test_overwrite(self):
+        """
+        Error is not raised when classes define a __getattr__()
+        and ``overwrite=True`` is passed.
+        """
+        set_default_for_missing_keys('hello world')
+        set_default_for_missing_keys(123, overwrite=True)
+
+        assert DotWiz().missing_key == 123
+
+    def test_overwrite_raises_an_error_by_default(self):
+        """Error is raised when classes already define a __getattr__()."""
+        set_default_for_missing_keys('test')
+
+        with pytest.raises(ValueError) as e:
+            set_default_for_missing_keys(None)
+
+        # confirm that error message correctly indicates the fix/resolution
+        assert 'pass `overwrite=True`' in str(e.value)
 
 
 def test_make_dot_wiz():

--- a/tests/unit/test_dotwiz_plus.py
+++ b/tests/unit/test_dotwiz_plus.py
@@ -2,7 +2,9 @@
 
 import pytest
 
-from dotwiz import DotWizPlus, make_dot_wiz_plus
+from dotwiz import *
+
+from .conftest import CleanupGetAttr
 
 
 def test_dot_wiz_plus_with_basic_usage():
@@ -37,6 +39,37 @@ def test_make_dot_wiz_plus():
 
     dd.b = [1, 2, 3]
     assert dd.b == [1, 2, 3]
+
+
+class TestDefaultForMissingKeys(CleanupGetAttr):
+
+    def test_usage(self):
+        """Basic usage of :func:`set_default_for_missing_keys`."""
+        set_default_for_missing_keys()
+
+        dw = DotWizPlus(HelloWorld=True)
+        assert dw.hello_world
+        assert dw.world is None
+
+    def test_overwrite(self):
+        """
+        Error is not raised when classes define a __getattr__()
+        and ``overwrite=True`` is passed.
+        """
+        set_default_for_missing_keys('hello world')
+        set_default_for_missing_keys(123, overwrite=True)
+
+        assert DotWizPlus().missing_key == 123
+
+    def test_overwrite_raises_an_error_by_default(self):
+        """Error is raised when classes already define a __getattr__()."""
+        set_default_for_missing_keys('test')
+
+        with pytest.raises(ValueError) as e:
+            set_default_for_missing_keys(None)
+
+        # confirm that error message correctly indicates the fix/resolution
+        assert 'pass `overwrite=True`' in str(e.value)
 
 
 def test_dotwiz_plus_init():


### PR DESCRIPTION
add `set_default_for_missing_keys()`. closes #14 

**Usage:**

```python3
from dotwiz import DotWiz, set_default_for_missing_keys

set_default_for_missing_keys()

dw = DotWiz(hello='world!')
assert dw.hello == 'world!'
assert dw.world is None
```

