### PR TITLE
fix https://github.com/rnag/dotwiz/issues/24

### DIFF
--- a/dotwiz/main.py
+++ b/dotwiz/main.py
@@ -87,11 +87,11 @@ class DotWiz(dict, metaclass=__add_repr__, print_char='✫'):
 
     __init__ = update = __upsert_into_dot_wiz__
 
-    __delattr__ = __delitem__ = dict.__delitem__
     __setattr__ = __setitem__ = __setitem_impl__
 
-    def __getitem__(self, key):
-        return self.__dict__[key]
+    def __delattr__(self, key):
+        super().pop(key)
+        super().__delattr__(key)
 
     to_dict = __convert_to_dict__
     to_dict.__doc__ = 'Recursively convert the :class:`DotWiz` instance ' \

--- a/tests/unit/test_dotwiz.py
+++ b/tests/unit/test_dotwiz.py
@@ -206,3 +206,41 @@ def test_dotwiz_to_dict():
             }
         ]
     }
+
+
+def assert_raises(fn, typ):
+    try:
+        fn()
+    except typ:
+        return
+    except Exception as e:
+        assert False, f"expected {typ}, got {type(e)}"
+    assert False, f"expected {typ}, got no exception"
+
+
+def test_del():
+    # https://github.com/rnag/dotwiz/issues/24
+    d = DotWiz()
+    d.a1 = 1
+    d.a2 = 2
+    assert d.get("a1")==1
+    assert d.get("bad") is None
+    assert d.get("bad", 3) == 3
+    assert str(d)=="✫(a1=1, a2=2)"
+    assert repr(d)=="✫(a1=1, a2=2)"
+    assert repr(d.__dict__)=="{'a1': 1, 'a2': 2}"
+    del d.a1
+    assert repr(d)=="✫(a2=2)"
+    assert_raises(lambda: d.a1, AttributeError)
+    assert_raises(lambda: d['a1'], KeyError)
+    # print(dir(d))
+    assert d.__dict__ == {'a2': 2}
+    assert list(d.__dict__.keys()) == ['a2']
+    assert list(d.keys()) == ['a2']
+    assert list(d.values()) == [2]
+
+    assert [a for a in d] == ['a2']
+    assert [a for a in d.items()] == [('a2', 2)]
+
+    d.a3 = DotWiz()
+    d.a3.a4 = 4


### PR DESCRIPTION
fix https://github.com/rnag/dotwiz/issues/24
@rnag @orlof 
also relevant articles:
https://stackoverflow.com/questions/51540806/how-to-auto-update-keys-from-a-class-inherited-from-dict/51541098#51541098
https://towardsdatascience.com/python-inheritance-should-you-inherit-from-dict-or-userdict-9b4450830cbb
https://treyhunner.com/2019/04/why-you-shouldnt-inherit-from-list-and-dict-in-python/
http://www.kr41.net/2016/03-23-dont_inherit_python_builtin_dict_type.html
https://stackoverflow.com/a/39375731/1426932


regarding inheriting from dict vs UserDict vs collections.abc.MutableMapping, which involves tradeoffs in performance vs complexity; in particular https://treyhunner.com/2019/04/why-you-shouldnt-inherit-from-list-and-dict-in-python/ sheds some light on why the bug was occuring. Future work should investigate deriving from collections.abc.MutableMapping which might have less gotchas compared to inheriting from dict, but maybe more performant than inheriting from UserDict
